### PR TITLE
Set Postgres statement and lock timeouts in milliseconds

### DIFF
--- a/lib/strong_migrations/checker.rb
+++ b/lib/strong_migrations/checker.rb
@@ -212,7 +212,7 @@ Then add the NOT NULL constraint."
         if StrongMigrations.statement_timeout
           statement =
             if postgresql?
-              "SET statement_timeout TO #{connection.quote(StrongMigrations.statement_timeout)}"
+              "SET statement_timeout TO #{connection.quote(StrongMigrations.statement_timeout.to_i * 1000)}"
             elsif mysql?
               "SET max_execution_time = #{connection.quote(StrongMigrations.statement_timeout.to_i * 1000)}"
             elsif mariadb?
@@ -227,7 +227,7 @@ Then add the NOT NULL constraint."
         if StrongMigrations.lock_timeout
           statement =
             if postgresql?
-              "SET lock_timeout TO #{connection.quote(StrongMigrations.lock_timeout)}"
+              "SET lock_timeout TO #{connection.quote(StrongMigrations.lock_timeout.to_i * 1000)}"
             elsif mysql? || mariadb?
               "SET lock_wait_timeout = #{connection.quote(StrongMigrations.lock_timeout)}"
             else


### PR DESCRIPTION
Postgres expects a number argument for statement and lock timeouts to be
in milliseconds. This results in the recently released migration-specific
timeouts being shorter than intended if the user sets them with
`StrongMigrations.statement_timeout=` and `.lock_timeout=`, as PG
interprets seconds as milliseconds.

This change updates the checker to multiply the result by 1,000 if the
database is PG.

Co-authored-by: Susanna Kosonen <kosonen.susanna@gmail.com>